### PR TITLE
Reset variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,13 @@ var path = require('path'),
     extend = require('jquery-extend'),
     async = require('async'),
     fs = require('fs'),
-    mkdirp = require('mkdirp'),
-    licenses = {},
-    filePaths = [];
+    mkdirp = require('mkdirp');
 
 
 exports.dumpLicenses = function(args, callback) {
-    var reader = new DirectoryReader(args.start, args.exclude);
+    var reader = new DirectoryReader(args.start, args.exclude),
+        licenses = {},
+        filePaths = [];
     reader
         .on("file", function (file, stat, fullPath) {
             if (file === "package.json") {


### PR DESCRIPTION
If you call dumpLicenses more than once in a eg. grunt task, the second call uses the "old" variables from the first call.