### PR TITLE
Added option '--onlyDirectDependencies': show only direct dependencie…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Options
 
 * `--dependencies`: show only third-party licenses, i.e., only list the dependencies defined in package.json.
 
+* `--onlyDirectDependencies`: show only direct dependencies licenses, i.e., don't list dependencies of dependencies.
+
 * `--relativeLicensePath`: output the relative file path for license files.
 
 * `--json /path/to/save.json`: export data as JSON to the given file. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,11 +12,16 @@ exports.dumpLicenses = function(args, callback) {
     var reader = new DirectoryReader(args.start, args.exclude),
         licenses = {},
         filePaths = [];
+    const onlyDirectDependenciesFilter = {};
     reader
         .on("file", function (file, stat, fullPath) {
             if (file === "package.json") {
                 //console.log('Analyzing file: %s, %d bytes', file, stat.size, fullPath);
                 filePaths.push(fullPath);
+                if (args.onlyDirectDependencies) {
+                    let { dependencies, name } = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+                    onlyDirectDependenciesFilter[name] = Object.keys(dependencies);
+                }
             }
             reader.next();
         })
@@ -52,8 +57,15 @@ exports.dumpLicenses = function(args, callback) {
                         var result = {};
                         
                         Object.keys(licenses).sort().forEach(function(item) {
-                            if (licenses[item]) {
-                                result[item] = licenses[item];
+                            const license = licenses[item];
+                            if (license) {
+                                if (args.onlyDirectDependencies) {
+                                    let packageName = item.split("@")[0];
+                                    if (!onlyDirectDependenciesFilter[license.parents] || !onlyDirectDependenciesFilter[license.parents].includes(packageName)) {
+                                        return;
+                                    }
+                                }
+                                result[item] = license;
                             }
                         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,8 +19,8 @@ exports.dumpLicenses = function(args, callback) {
                 //console.log('Analyzing file: %s, %d bytes', file, stat.size, fullPath);
                 filePaths.push(fullPath);
                 if (args.onlyDirectDependencies) {
-                    let { dependencies, name } = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                    onlyDirectDependenciesFilter[name] = Object.keys(dependencies);
+                    var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+                    onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);
                 }
             }
             reader.next();
@@ -57,10 +57,10 @@ exports.dumpLicenses = function(args, callback) {
                         var result = {};
                         
                         Object.keys(licenses).sort().forEach(function(item) {
-                            const license = licenses[item];
+                            var license = licenses[item];
                             if (license) {
                                 if (args.onlyDirectDependencies) {
-                                    let packageName = item.split("@")[0];
+                                    var packageName = item.split("@")[0];
                                     if (!onlyDirectDependenciesFilter[license.parents] || !onlyDirectDependenciesFilter[license.parents].includes(packageName)) {
                                         return;
                                     }


### PR DESCRIPTION
…s licenses, i.e., don't list dependencies of dependencies.

https://github.com/mwittig/npm-license-crawler/issues/10