### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,9 @@ exports.dumpLicenses = function(args, callback) {
                 filePaths.push(fullPath);
                 if (args.onlyDirectDependencies) {
                     var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                    onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);
+                    if(packageJsonContents.dependencies && packageJsonContents.name){
+                        onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);
+                    }
                 }
             }
             reader.next();


### PR DESCRIPTION
fix the 
TypeError: Cannot convert undefined or null to object
    at DirectoryReader.<anonymous> (~/.nvm/versions/node/v6.10.2/lib/node_modules/npm-license-crawler/lib/index.js:23:85)
    at emitThree (events.js:116:13)
    at DirectoryReader.emit (events.js:194:7)
    at ~/.nvm/versions/node/v6.10.2/lib/node_modules/npm-license-crawler/lib/directoryreader.js:145:26
    at FSReqWrap.oncomplete (fs.js:123:15)