### PR TITLE
Include @-named dependencies with --onlyDirectDependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ exports.dumpLicenses = function(args, callback) {
                             var license = licenses[item];
                             if (license) {
                                 if (args.onlyDirectDependencies) {
-                                    var packageName = item.split("@")[0];
+                                    var packageName = item.substring(0, item.lastIndexOf("@"))
                                     if (!onlyDirectDependenciesFilter[license.parents] || onlyDirectDependenciesFilter[license.parents].indexOf(packageName) == -1) {
                                         return;
                                     }


### PR DESCRIPTION
Fixes https://github.com/mwittig/npm-license-crawler/issues/20

Output is now:
```
node ../npm-license-crawler/bin/npm-license-crawler --onlyDirectDependencies
...
├─ @godaddy/terminus@2.2.0
│  ├─ licenses: MIT
│  ├─ repository: https://github.com/godaddy/terminus
│  ├─ licenseUrl: https://github.com/godaddy/terminus/raw/master/LICENSE
│  └─ parents: fake
└─ lodash@4.17.10
   ├─ licenses: MIT
   ├─ repository: https://github.com/lodash/lodash
   ├─ licenseUrl: https://github.com/lodash/lodash/raw/master/LICENSE
   └─ parents: fake

Number of entries found: 2
```

for `package.json`:
```
{
  "name": "demo",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "@godaddy/terminus": "^2.2.0",
    "lodash": "^4.17.10"
  }
}
```