### PR TITLE
Fix namespaced packages when using omitVersion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,13 +61,13 @@ exports.dumpLicenses = function(args, callback) {
                         Object.keys(licenses).sort().forEach(function(item) {
                             var license = licenses[item];
                             if (license) {
+                                var packageName = item.substring(0, item.lastIndexOf("@"))
                                 if (args.onlyDirectDependencies) {
-                                    var packageName = item.substring(0, item.lastIndexOf("@"))
                                     if (!onlyDirectDependenciesFilter[license.parents] || onlyDirectDependenciesFilter[license.parents].indexOf(packageName) == -1) {
                                         return;
                                     }
                                 }
-                                var resultKey = args.omitVersion ? item.split("@")[0] : item;
+                                var resultKey = args.omitVersion ? packageName : item;
                                 result[resultKey] = license;
                             }
                         });


### PR DESCRIPTION
Using `split('@')` doesn't work for namespaced packages, just use the same `packageName` variable instead that already handles removing the version properly.