### PR TITLE
Fix: OnlyDirectDependencies and DevDependencies Option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,9 @@ exports.dumpLicenses = function(args, callback) {
                 filePaths.push(fullPath);
                 if (args.onlyDirectDependencies) {
                     var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                    if(packageJsonContents.dependencies && packageJsonContents.name){
+                    f (args.development && packageJsonContents.dependencies && packageJsonContents.name) {
+                        onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.devDependencies);
+                    } else if(packageJsonContents.dependencies && packageJsonContents.name){
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);
                     }
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ exports.dumpLicenses = function(args, callback) {
                 filePaths.push(fullPath);
                 if (args.onlyDirectDependencies) {
                     var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                    f (args.development && packageJsonContents.dependencies && packageJsonContents.name) {
+                    if (args.development && packageJsonContents.dependencies && packageJsonContents.name) {
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.devDependencies);
                     } else if(packageJsonContents.dependencies && packageJsonContents.name){
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);


### PR DESCRIPTION
When the Options `onlyDirectDependencies` was provided, the script always took the `dependencies`, even if the flag `devDependencies` was provided. This Change gives you only the direct development dependencies if the flags `onlyDirectDependencies` & `devDependencies` ist provided. When `onlyDirectDependencies` is the provided without the `devDependencies` Options, it will return the normal dependencies.

fixes #11 