### PR TITLE
Check devDependencies when development flag is active

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ exports.dumpLicenses = function(args, callback) {
                 filePaths.push(fullPath);
                 if (args.onlyDirectDependencies) {
                     var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-                    if (args.development && packageJsonContents.dependencies && packageJsonContents.name) {
+                    if (args.development && packageJsonContents.devDependencies && packageJsonContents.name) {
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.devDependencies);
                     } else if(packageJsonContents.dependencies && packageJsonContents.name){
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);


### PR DESCRIPTION
Before the onlyDirectDependenciesFilter is initialized for the
devDependencies, the packageJsonContents.devDependencies needs to be
checked instead of the packageJsonContents.dependencies, otherwise
if there are not any dependencies in the package json, the output
will be empty.