### PR TITLE
Don't blow up if there's no dev dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ exports.dumpLicenses = function(args, callback) {
                 if (args.onlyDirectDependencies) {
                     var packageJsonContents = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
                     if (args.development && packageJsonContents.devDependencies && packageJsonContents.name) {
-                        onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.devDependencies);
+                        onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.devDependencies || {});
                     } else if(packageJsonContents.dependencies && packageJsonContents.name){
                         onlyDirectDependenciesFilter[packageJsonContents.name] = Object.keys(packageJsonContents.dependencies);
                     }


### PR DESCRIPTION
Fix for: `npm-license-crawler --onlyDirectDependencies --development` blowing up when it encounters a package.json with no dev dependencies

Encountered this because we have some little lambda projects