### PR TITLE
fixing exclude dirs

### DIFF
--- a/lib/directoryreader.js
+++ b/lib/directoryreader.js
@@ -100,7 +100,7 @@ DirectoryReader.prototype._cwd = function() {
 
 DirectoryReader.prototype._isExcludedDir = function() {
     var excludeDirs = this.excludeDirs,
-        dir = this.currentFilePath;
+        dir = path.resolve(this.currentFilePath);
 
     for (var i=0; i<excludeDirs.length;++i) {
         if (dir.indexOf(excludeDirs[i]) === 0) {


### PR DESCRIPTION
This fixes exclude dirs for win env with unix paths.
example:
```
exclude: ['./functionnal', './tools'],
// outputs:
exclude dir C:\projects\foo/functionnal
exclude dir C:\projects\foo/tools
```
So with path.resolve(), it's working properly.